### PR TITLE
travis: Make the build script independent of the fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 before_script:
   - gox -os="darwin linux windows" -arch="386 amd64" -build-toolchain
 script:
-  - gox -os="darwin linux windows" -arch="386 amd64" github.com/prydonius/karn/cmd/karn
+  - gox -os="darwin linux windows" -arch="386 amd64" ./cmd/karn
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
This way forks do not have to adjust the .travis.yml file to make CI work.
Deploying releases from forks would still require changing the OAuth token,
though.