### PR TITLE
Adds Arch Linux package to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ brew install karn
 ```
 
 ### Pre-built binary
-Head to the [releases](https://github.com/prydonius/karn/releases) page to download pre-built binaries for OS X. Note that karn is currently only tested on OS X.
+Head to the [releases](https://github.com/prydonius/karn/releases) page to download pre-built binaries for OS X/Linux/Windows.
 
 ### Go
 You can install karn using Go with the following command:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ You can install karn using Go with the following command:
 go get github.com/prydonius/karn/cmd/karn
 ```
 
+### Arch Linux
+
+`karn` has a AUR package: <https://aur.archlinux.org/packages/karn/>. You can install it using your [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) of choice.
+
 ## Usage
 karn can be used in two ways!
 


### PR DESCRIPTION
Since I've been using it for quite some time on Arch, decided to remove the OS X only note.